### PR TITLE
add active flag to gdax

### DIFF
--- a/js/gdax.js
+++ b/js/gdax.js
@@ -178,6 +178,7 @@ module.exports = class gdax extends Exchange {
             if ((base == 'ETH') || (base == 'LTC')) {
                 taker = 0.003;
             }
+            let active = market['status'] == 'online';
             result.push (this.extend (this.fees['trading'], {
                 'id': id,
                 'symbol': symbol,
@@ -187,6 +188,7 @@ module.exports = class gdax extends Exchange {
                 'precision': precision,
                 'limits': limits,
                 'taker': taker,
+                'active': active,
             }));
         }
         return result;


### PR DESCRIPTION
gdax has an (undocumented) "status" attribute with a known value of "online".
This patch for javascript adds the active attribute for gdax set to `true` if `status` contains the value `online`.

Related to issue #1179.